### PR TITLE
Set status to null if the form group is pristine

### DIFF
--- a/src/form-group.coffee
+++ b/src/form-group.coffee
@@ -8,6 +8,7 @@ class FormGroupController
     @$scope.$on "$destroy", unref
 
   update: =>
+    @status = null
     return unless @inputs.every (i) -> i.$dirty
     @status = if (@inputs.every (i) -> i.$valid) then "success" else "error"
     @$scope.$digest() unless @$scope.$$phase


### PR DESCRIPTION
Set status to null if the form group is pristine so that the has-error and has-success classes get removed
