### PR TITLE
Fix styles not updating when pristine form is submitted.

### DIFF
--- a/src/form-group.coffee
+++ b/src/form-group.coffee
@@ -9,7 +9,7 @@ class FormGroupController
 
   update: =>
     @status = null
-    return unless @inputs.every (i) -> i.$dirty and not i.$pending
+    return unless @inputs.every (i) -> (i.$dirty and not i.$pending) or i.$$parentForm.$submitted
     @status = if (@inputs.every (i) -> i.$valid) then "success" else "error"
     @$scope.$digest() unless @$scope.$$phase
 

--- a/tests/form-group.coffee
+++ b/tests/form-group.coffee
@@ -41,6 +41,21 @@ describe 'The classy form-group directive', ->
     expect(el.hasClass('has-error')).toBe(false)
     expect(el.hasClass('has-success')).toBe(true)
 
+  it "should apply classes when the form is submitted - even if pristine", ->
+    scope = undefined;
+    inject ($rootScope) -> scope = $rootScope
+
+    [el, ctrl] = factory """
+        <input name="aInput" ng-model="foo" required class="form-control">
+        <input name="bInput" ng-model="bar" required class="form-control">
+    """
+
+    ctrl.$setSubmitted();
+    scope.$digest();
+
+    expect(el.hasClass('has-error')).toBe(true)
+    expect(el.hasClass('has-success')).toBe(false)
+
   it "should bypass elements with the class `form-group-without-feedback`", ->
     [el, ctrl] = factory('<input name="input" ng-model="foo" required class="form-control">', 'form-group-without-feedback')
 


### PR DESCRIPTION
Currently if a user tries to submit a pristine form none of the validation classes are applied. The form is invalid but no visual style is updated.

This modifies the form-group group directive so that validation styles will be applied when a submit button is pressed and the form is still in an invalid state.
